### PR TITLE
upgrade dependencies, fix lightbox css

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
                 "clsx": "^2.0.0",
                 "mermaid": "^10.6.1",
                 "photoswipe": "^5.4.3",
-                "plugin-image-zoom": "github:flexanalytics/plugin-image-zoom",
                 "prism-react-renderer": "^2.3.0",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0"
@@ -9771,11 +9770,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/medium-zoom": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/medium-zoom/-/medium-zoom-1.1.0.tgz",
-            "integrity": "sha512-ewyDsp7k4InCUp3jRmwHBRFGyjBimKps/AJLjRSox+2q/2H4p/PNpQf+pwONWlJiOudkBXtbdmVbFjqyybfTmQ=="
-        },
         "node_modules/memfs": {
             "version": "3.5.3",
             "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
@@ -12733,14 +12727,6 @@
             "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/plugin-image-zoom": {
-            "version": "1.1.0",
-            "resolved": "git+ssh://git@github.com/flexanalytics/plugin-image-zoom.git#8e1b866c79ed6d42cefc4c52f851f1dfd1d0c7de",
-            "license": "MIT",
-            "dependencies": {
-                "medium-zoom": "^1.0.8"
             }
         },
         "node_modules/png-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,20 +8,20 @@
             "name": "docs",
             "version": "0.0.0",
             "dependencies": {
-                "@docusaurus/core": "3.0.0",
-                "@docusaurus/preset-classic": "3.0.0",
-                "@docusaurus/theme-mermaid": "^3.0.0",
+                "@docusaurus/core": "^3.0.1",
+                "@docusaurus/preset-classic": "^3.0.1",
+                "@docusaurus/theme-mermaid": "^3.0.1",
                 "@mdx-js/react": "^3.0.0",
                 "clsx": "^2.0.0",
                 "mermaid": "^10.6.1",
-                "photoswipe": "^5.4.2",
+                "photoswipe": "^5.4.3",
                 "plugin-image-zoom": "github:flexanalytics/plugin-image-zoom",
-                "prism-react-renderer": "^2.1.0",
+                "prism-react-renderer": "^2.3.0",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0"
             },
             "devDependencies": {
-                "@docusaurus/module-type-aliases": "3.0.0",
+                "@docusaurus/module-type-aliases": "^3.0.1",
                 "@hylimo/cli": "^0.0.1",
                 "prettier": "^3.1.0"
             },
@@ -203,9 +203,9 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.23.4",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.4.tgz",
-            "integrity": "sha512-r1IONyb6Ia+jYR2vvIDhdWdlTGhqbBoFqLTQidzZ4kepUFH15ejXvFHxCVbtl7BOXIudsIubf4E81xeA3h3IXA==",
+            "version": "7.23.5",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+            "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
             "dependencies": {
                 "@babel/highlight": "^7.23.4",
                 "chalk": "^2.4.2"
@@ -279,28 +279,28 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.3.tgz",
-            "integrity": "sha512-BmR4bWbDIoFJmJ9z2cZ8Gmm2MXgEDgjdWgpKmKWUt54UGFJdlj31ECtbaDvCG/qVdG3AQ1SfpZEs01lUFbzLOQ==",
+            "version": "7.23.5",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
+            "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.3.tgz",
-            "integrity": "sha512-Jg+msLuNuCJDyBvFv5+OKOUjWMZgd85bKjbICd3zWrKAo+bJ49HJufi7CQE0q0uR8NGyO6xkCACScNqyjHSZew==",
+            "version": "7.23.5",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.5.tgz",
+            "integrity": "sha512-Cwc2XjUrG4ilcfOw4wBAK+enbdgwAcAJCfGUItPBKR7Mjw4aEfAFYrLxeRp4jWgtNIKn3n2AlBOfwwafl+42/g==",
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.22.13",
-                "@babel/generator": "^7.23.3",
+                "@babel/code-frame": "^7.23.5",
+                "@babel/generator": "^7.23.5",
                 "@babel/helper-compilation-targets": "^7.22.15",
                 "@babel/helper-module-transforms": "^7.23.3",
-                "@babel/helpers": "^7.23.2",
-                "@babel/parser": "^7.23.3",
+                "@babel/helpers": "^7.23.5",
+                "@babel/parser": "^7.23.5",
                 "@babel/template": "^7.22.15",
-                "@babel/traverse": "^7.23.3",
-                "@babel/types": "^7.23.3",
+                "@babel/traverse": "^7.23.5",
+                "@babel/types": "^7.23.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -324,11 +324,11 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.23.4",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.4.tgz",
-            "integrity": "sha512-esuS49Cga3HcThFNebGhlgsrVLkvhqvYDTzgjfFFlHJcIfLe5jFmRRfCQ1KuBfc4Jrtn3ndLgKWAKjBE+IraYQ==",
+            "version": "7.23.5",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.5.tgz",
+            "integrity": "sha512-BPssCHrBD+0YrxviOa3QzpqwhNIXKEtOa2jQrm4FlmkC2apYgRnQcmPWiGZDlGxiNtltnUFolMe8497Esry+jA==",
             "dependencies": {
-                "@babel/types": "^7.23.4",
+                "@babel/types": "^7.23.5",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "@jridgewell/trace-mapping": "^0.3.17",
                 "jsesc": "^2.5.1"
@@ -383,16 +383,16 @@
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.15.tgz",
-            "integrity": "sha512-jKkwA59IXcvSaiK2UN45kKwSC9o+KuoXsBDvHvU/7BecYIp8GQ2UwrVvFgJASUT+hBnwJx6MhvMCuMzwZZ7jlg==",
+            "version": "7.23.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.5.tgz",
+            "integrity": "sha512-QELlRWxSpgdwdJzSJn4WAhKC+hvw/AtHbbrIoncKHkhKKR/luAlKkgBDcri1EzWAo8f8VvYVryEHN4tax/V67A==",
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
-                "@babel/helper-environment-visitor": "^7.22.5",
-                "@babel/helper-function-name": "^7.22.5",
-                "@babel/helper-member-expression-to-functions": "^7.22.15",
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-function-name": "^7.23.0",
+                "@babel/helper-member-expression-to-functions": "^7.23.0",
                 "@babel/helper-optimise-call-expression": "^7.22.5",
-                "@babel/helper-replace-supers": "^7.22.9",
+                "@babel/helper-replace-supers": "^7.22.20",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
                 "@babel/helper-split-export-declaration": "^7.22.6",
                 "semver": "^6.3.1"
@@ -623,9 +623,9 @@
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
-            "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
+            "version": "7.23.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+            "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -644,13 +644,13 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.23.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.4.tgz",
-            "integrity": "sha512-HfcMizYz10cr3h29VqyfGL6ZWIjTwWfvYBMsBVGwpcbhNGe3wQ1ZXZRPzZoAHhd9OqHadHqjQ89iVKINXnbzuw==",
+            "version": "7.23.5",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.5.tgz",
+            "integrity": "sha512-oO7us8FzTEsG3U6ag9MfdF1iA/7Z6dz+MtFhifZk8C8o453rGJFFWUP1t+ULM9TUIAzC9uxXEiXjOiVMyd7QPg==",
             "dependencies": {
                 "@babel/template": "^7.22.15",
-                "@babel/traverse": "^7.23.4",
-                "@babel/types": "^7.23.4"
+                "@babel/traverse": "^7.23.5",
+                "@babel/types": "^7.23.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -734,9 +734,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.23.4",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.4.tgz",
-            "integrity": "sha512-vf3Xna6UEprW+7t6EtOmFpHNAuxw3xqPZghy+brsnusscJRW5BMUzzHZc5ICjULee81WeUV2jjakG09MDglJXQ==",
+            "version": "7.23.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.5.tgz",
+            "integrity": "sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==",
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -1152,9 +1152,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-classes": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.23.3.tgz",
-            "integrity": "sha512-FGEQmugvAEu2QtgtU0uTASXevfLMFfBeVCIIdcQhn/uBQsMTjBajdnAtanQlOcuihWh10PZ7+HWvc7NtBwP74w==",
+            "version": "7.23.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.23.5.tgz",
+            "integrity": "sha512-jvOTR4nicqYC9yzOHIhXG5emiFEOpappSJAl73SDSEDcybD+Puuze8Tnpb9p9qEyYup24tq891gkaygIFvWDqg==",
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
                 "@babel/helper-compilation-targets": "^7.22.15",
@@ -1813,12 +1813,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-typescript": {
-            "version": "7.23.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.23.4.tgz",
-            "integrity": "sha512-39hCCOl+YUAyMOu6B9SmUTiHUU0t/CxJNUmY3qRdJujbqi+lrQcL11ysYUsAvFWPBdhihrv1z0oRG84Yr3dODQ==",
+            "version": "7.23.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.23.5.tgz",
+            "integrity": "sha512-2fMkXEJkrmwgu2Bsv1Saxgj30IXZdJ+84lQcKKI7sm719oXs0BBw2ZENKdJdR1PjWndgLCEBNXJOri0fk7RYQA==",
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
-                "@babel/helper-create-class-features-plugin": "^7.22.15",
+                "@babel/helper-create-class-features-plugin": "^7.23.5",
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/plugin-syntax-typescript": "^7.23.3"
             },
@@ -1889,14 +1889,14 @@
             }
         },
         "node_modules/@babel/preset-env": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.3.tgz",
-            "integrity": "sha512-ovzGc2uuyNfNAs/jyjIGxS8arOHS5FENZaNn4rtE7UdKMMkqHCvboHfcuhWLZNX5cB44QfcGNWjaevxMzzMf+Q==",
+            "version": "7.23.5",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.5.tgz",
+            "integrity": "sha512-0d/uxVD6tFGWXGDSfyMD1p2otoaKmu6+GD+NfAx0tMaH+dxORnp7T9TaVQ6mKyya7iBtCIVxHjWT7MuzzM9z+A==",
             "dependencies": {
-                "@babel/compat-data": "^7.23.3",
+                "@babel/compat-data": "^7.23.5",
                 "@babel/helper-compilation-targets": "^7.22.15",
                 "@babel/helper-plugin-utils": "^7.22.5",
-                "@babel/helper-validator-option": "^7.22.15",
+                "@babel/helper-validator-option": "^7.23.5",
                 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.23.3",
                 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.23.3",
                 "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.23.3",
@@ -1920,25 +1920,25 @@
                 "@babel/plugin-syntax-top-level-await": "^7.14.5",
                 "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
                 "@babel/plugin-transform-arrow-functions": "^7.23.3",
-                "@babel/plugin-transform-async-generator-functions": "^7.23.3",
+                "@babel/plugin-transform-async-generator-functions": "^7.23.4",
                 "@babel/plugin-transform-async-to-generator": "^7.23.3",
                 "@babel/plugin-transform-block-scoped-functions": "^7.23.3",
-                "@babel/plugin-transform-block-scoping": "^7.23.3",
+                "@babel/plugin-transform-block-scoping": "^7.23.4",
                 "@babel/plugin-transform-class-properties": "^7.23.3",
-                "@babel/plugin-transform-class-static-block": "^7.23.3",
-                "@babel/plugin-transform-classes": "^7.23.3",
+                "@babel/plugin-transform-class-static-block": "^7.23.4",
+                "@babel/plugin-transform-classes": "^7.23.5",
                 "@babel/plugin-transform-computed-properties": "^7.23.3",
                 "@babel/plugin-transform-destructuring": "^7.23.3",
                 "@babel/plugin-transform-dotall-regex": "^7.23.3",
                 "@babel/plugin-transform-duplicate-keys": "^7.23.3",
-                "@babel/plugin-transform-dynamic-import": "^7.23.3",
+                "@babel/plugin-transform-dynamic-import": "^7.23.4",
                 "@babel/plugin-transform-exponentiation-operator": "^7.23.3",
-                "@babel/plugin-transform-export-namespace-from": "^7.23.3",
+                "@babel/plugin-transform-export-namespace-from": "^7.23.4",
                 "@babel/plugin-transform-for-of": "^7.23.3",
                 "@babel/plugin-transform-function-name": "^7.23.3",
-                "@babel/plugin-transform-json-strings": "^7.23.3",
+                "@babel/plugin-transform-json-strings": "^7.23.4",
                 "@babel/plugin-transform-literals": "^7.23.3",
-                "@babel/plugin-transform-logical-assignment-operators": "^7.23.3",
+                "@babel/plugin-transform-logical-assignment-operators": "^7.23.4",
                 "@babel/plugin-transform-member-expression-literals": "^7.23.3",
                 "@babel/plugin-transform-modules-amd": "^7.23.3",
                 "@babel/plugin-transform-modules-commonjs": "^7.23.3",
@@ -1946,15 +1946,15 @@
                 "@babel/plugin-transform-modules-umd": "^7.23.3",
                 "@babel/plugin-transform-named-capturing-groups-regex": "^7.22.5",
                 "@babel/plugin-transform-new-target": "^7.23.3",
-                "@babel/plugin-transform-nullish-coalescing-operator": "^7.23.3",
-                "@babel/plugin-transform-numeric-separator": "^7.23.3",
-                "@babel/plugin-transform-object-rest-spread": "^7.23.3",
+                "@babel/plugin-transform-nullish-coalescing-operator": "^7.23.4",
+                "@babel/plugin-transform-numeric-separator": "^7.23.4",
+                "@babel/plugin-transform-object-rest-spread": "^7.23.4",
                 "@babel/plugin-transform-object-super": "^7.23.3",
-                "@babel/plugin-transform-optional-catch-binding": "^7.23.3",
-                "@babel/plugin-transform-optional-chaining": "^7.23.3",
+                "@babel/plugin-transform-optional-catch-binding": "^7.23.4",
+                "@babel/plugin-transform-optional-chaining": "^7.23.4",
                 "@babel/plugin-transform-parameters": "^7.23.3",
                 "@babel/plugin-transform-private-methods": "^7.23.3",
-                "@babel/plugin-transform-private-property-in-object": "^7.23.3",
+                "@babel/plugin-transform-private-property-in-object": "^7.23.4",
                 "@babel/plugin-transform-property-literals": "^7.23.3",
                 "@babel/plugin-transform-regenerator": "^7.23.3",
                 "@babel/plugin-transform-reserved-words": "^7.23.3",
@@ -2045,9 +2045,9 @@
             "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
         },
         "node_modules/@babel/runtime": {
-            "version": "7.23.4",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.4.tgz",
-            "integrity": "sha512-2Yv65nlWnWlSpe3fXEyX5i7fx5kIKo4Qbcj+hMO0odwaneFjfXw5fdum+4yL20O0QiaHpia0cYQ9xpNMqrBwHg==",
+            "version": "7.23.5",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.5.tgz",
+            "integrity": "sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==",
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
             },
@@ -2056,9 +2056,9 @@
             }
         },
         "node_modules/@babel/runtime-corejs3": {
-            "version": "7.23.4",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.23.4.tgz",
-            "integrity": "sha512-zQyB4MJGM+rvd4pM58n26kf3xbiitw9MHzL8oLiBMKb8MCtVDfV5nDzzJWWzLMtbvKI9wN6XwJYl479qF4JluQ==",
+            "version": "7.23.5",
+            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.23.5.tgz",
+            "integrity": "sha512-7+ziVclejQTLYhXl+Oi1f6gTGD1XDCeLa4R472TNGQxb08zbEJ0OdNoh5Piz+57Ltmui6xR88BXR4gS3/Toslw==",
             "dependencies": {
                 "core-js-pure": "^3.30.2",
                 "regenerator-runtime": "^0.14.0"
@@ -2081,18 +2081,18 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.23.4",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.4.tgz",
-            "integrity": "sha512-IYM8wSUwunWTB6tFC2dkKZhxbIjHoWemdK+3f8/wq8aKhbUscxD5MX72ubd90fxvFknaLPeGw5ycU84V1obHJg==",
+            "version": "7.23.5",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.5.tgz",
+            "integrity": "sha512-czx7Xy5a6sapWWRx61m1Ke1Ra4vczu1mCTtJam5zRTBOonfdJ+S/B6HYmGYu3fJtr8GGET3si6IhgWVBhJ/m8w==",
             "dependencies": {
-                "@babel/code-frame": "^7.23.4",
-                "@babel/generator": "^7.23.4",
+                "@babel/code-frame": "^7.23.5",
+                "@babel/generator": "^7.23.5",
                 "@babel/helper-environment-visitor": "^7.22.20",
                 "@babel/helper-function-name": "^7.23.0",
                 "@babel/helper-hoist-variables": "^7.22.5",
                 "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/parser": "^7.23.4",
-                "@babel/types": "^7.23.4",
+                "@babel/parser": "^7.23.5",
+                "@babel/types": "^7.23.5",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             },
@@ -2101,9 +2101,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.23.4",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.4.tgz",
-            "integrity": "sha512-7uIFwVYpoplT5jp/kVv6EF93VaJ8H+Yn5IczYiaAi98ajzjfoZfslet/e0sLh+wVBjb2qqIut1b0S26VSafsSQ==",
+            "version": "7.23.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.5.tgz",
+            "integrity": "sha512-ON5kSOJwVO6xXVRTvOI0eOnWe7VdUcIpsovGo9U/Br4Ie4UVFQTboO2cYnDhAGU6Fp+UxSiT+pMft0SMHfuq6w==",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.23.4",
                 "@babel/helper-validator-identifier": "^7.22.20",
@@ -2205,12 +2205,12 @@
             }
         },
         "node_modules/@docusaurus/core": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.0.0.tgz",
-            "integrity": "sha512-bHWtY55tJTkd6pZhHrWz1MpWuwN4edZe0/UWgFF7PW/oJeDZvLSXKqwny3L91X1/LGGoypBGkeZn8EOuKeL4yQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.0.1.tgz",
+            "integrity": "sha512-CXrLpOnW+dJdSv8M5FAJ3JBwXtL6mhUWxFA8aS0ozK6jBG/wgxERk5uvH28fCeFxOGbAT9v1e9dOMo1X2IEVhQ==",
             "dependencies": {
-                "@babel/core": "^7.22.9",
-                "@babel/generator": "^7.22.9",
+                "@babel/core": "^7.23.3",
+                "@babel/generator": "^7.23.3",
                 "@babel/plugin-syntax-dynamic-import": "^7.8.3",
                 "@babel/plugin-transform-runtime": "^7.22.9",
                 "@babel/preset-env": "^7.22.9",
@@ -2219,13 +2219,13 @@
                 "@babel/runtime": "^7.22.6",
                 "@babel/runtime-corejs3": "^7.22.6",
                 "@babel/traverse": "^7.22.8",
-                "@docusaurus/cssnano-preset": "3.0.0",
-                "@docusaurus/logger": "3.0.0",
-                "@docusaurus/mdx-loader": "3.0.0",
+                "@docusaurus/cssnano-preset": "3.0.1",
+                "@docusaurus/logger": "3.0.1",
+                "@docusaurus/mdx-loader": "3.0.1",
                 "@docusaurus/react-loadable": "5.5.2",
-                "@docusaurus/utils": "3.0.0",
-                "@docusaurus/utils-common": "3.0.0",
-                "@docusaurus/utils-validation": "3.0.0",
+                "@docusaurus/utils": "3.0.1",
+                "@docusaurus/utils-common": "3.0.1",
+                "@docusaurus/utils-validation": "3.0.1",
                 "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
                 "@svgr/webpack": "^6.5.1",
                 "autoprefixer": "^10.4.14",
@@ -2273,7 +2273,6 @@
                 "tslib": "^2.6.0",
                 "update-notifier": "^6.0.2",
                 "url-loader": "^4.1.1",
-                "wait-on": "^7.0.1",
                 "webpack": "^5.88.1",
                 "webpack-bundle-analyzer": "^4.9.0",
                 "webpack-dev-server": "^4.15.1",
@@ -2292,9 +2291,9 @@
             }
         },
         "node_modules/@docusaurus/cssnano-preset": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.0.0.tgz",
-            "integrity": "sha512-FHiRfwmVvIVdIGsHcijUOaX7hMn0mugVYB7m4GkpYI6Mi56zwQV4lH5p7DxcW5CUYNWMVxz2loWSCiWEm5ikwA==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.0.1.tgz",
+            "integrity": "sha512-wjuXzkHMW+ig4BD6Ya1Yevx9UJadO4smNZCEljqBoQfIQrQskTswBs7lZ8InHP7mCt273a/y/rm36EZhqJhknQ==",
             "dependencies": {
                 "cssnano-preset-advanced": "^5.3.10",
                 "postcss": "^8.4.26",
@@ -2306,9 +2305,9 @@
             }
         },
         "node_modules/@docusaurus/logger": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.0.0.tgz",
-            "integrity": "sha512-6eX0eOfioMQCk+qgCnHvbLLuyIAA+r2lSID6d6JusiLtDKmYMfNp3F4yyE8bnb0Abmzt2w68XwptEFYyALSAXw==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.0.1.tgz",
+            "integrity": "sha512-I5L6Nk8OJzkVA91O2uftmo71LBSxe1vmOn9AMR6JRCzYeEBrqneWMH02AqMvjJ2NpMiviO+t0CyPjyYV7nxCWQ==",
             "dependencies": {
                 "chalk": "^4.1.2",
                 "tslib": "^2.6.0"
@@ -2318,15 +2317,15 @@
             }
         },
         "node_modules/@docusaurus/mdx-loader": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.0.0.tgz",
-            "integrity": "sha512-JkGge6WYDrwjNgMxwkb6kNQHnpISt5L1tMaBWFDBKeDToFr5Kj29IL35MIQm0RfrnoOfr/29RjSH4aRtvlAR0A==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.0.1.tgz",
+            "integrity": "sha512-ldnTmvnvlrONUq45oKESrpy+lXtbnTcTsFkOTIDswe5xx5iWJjt6eSa0f99ZaWlnm24mlojcIGoUWNCS53qVlQ==",
             "dependencies": {
                 "@babel/parser": "^7.22.7",
                 "@babel/traverse": "^7.22.8",
-                "@docusaurus/logger": "3.0.0",
-                "@docusaurus/utils": "3.0.0",
-                "@docusaurus/utils-validation": "3.0.0",
+                "@docusaurus/logger": "3.0.1",
+                "@docusaurus/utils": "3.0.1",
+                "@docusaurus/utils-validation": "3.0.1",
                 "@mdx-js/mdx": "^3.0.0",
                 "@slorber/remark-comment": "^1.0.0",
                 "escape-html": "^1.0.3",
@@ -2358,12 +2357,12 @@
             }
         },
         "node_modules/@docusaurus/module-type-aliases": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.0.0.tgz",
-            "integrity": "sha512-CfC6CgN4u/ce+2+L1JdsHNyBd8yYjl4De2B2CBj2a9F7WuJ5RjV1ciuU7KDg8uyju+NRVllRgvJvxVUjCdkPiw==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.0.1.tgz",
+            "integrity": "sha512-DEHpeqUDsLynl3AhQQiO7AbC7/z/lBra34jTcdYuvp9eGm01pfH1wTVq8YqWZq6Jyx0BgcVl/VJqtE9StRd9Ag==",
             "dependencies": {
                 "@docusaurus/react-loadable": "5.5.2",
-                "@docusaurus/types": "3.0.0",
+                "@docusaurus/types": "3.0.1",
                 "@types/history": "^4.7.11",
                 "@types/react": "*",
                 "@types/react-router-config": "*",
@@ -2377,17 +2376,17 @@
             }
         },
         "node_modules/@docusaurus/plugin-content-blog": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.0.0.tgz",
-            "integrity": "sha512-iA8Wc3tIzVnROJxrbIsU/iSfixHW16YeW9RWsBw7hgEk4dyGsip9AsvEDXobnRq3lVv4mfdgoS545iGWf1Ip9w==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.0.1.tgz",
+            "integrity": "sha512-cLOvtvAyaMQFLI8vm4j26svg3ktxMPSXpuUJ7EERKoGbfpJSsgtowNHcRsaBVmfuCsRSk1HZ/yHBsUkTmHFEsg==",
             "dependencies": {
-                "@docusaurus/core": "3.0.0",
-                "@docusaurus/logger": "3.0.0",
-                "@docusaurus/mdx-loader": "3.0.0",
-                "@docusaurus/types": "3.0.0",
-                "@docusaurus/utils": "3.0.0",
-                "@docusaurus/utils-common": "3.0.0",
-                "@docusaurus/utils-validation": "3.0.0",
+                "@docusaurus/core": "3.0.1",
+                "@docusaurus/logger": "3.0.1",
+                "@docusaurus/mdx-loader": "3.0.1",
+                "@docusaurus/types": "3.0.1",
+                "@docusaurus/utils": "3.0.1",
+                "@docusaurus/utils-common": "3.0.1",
+                "@docusaurus/utils-validation": "3.0.1",
                 "cheerio": "^1.0.0-rc.12",
                 "feed": "^4.2.2",
                 "fs-extra": "^11.1.1",
@@ -2408,17 +2407,17 @@
             }
         },
         "node_modules/@docusaurus/plugin-content-docs": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.0.0.tgz",
-            "integrity": "sha512-MFZsOSwmeJ6rvoZMLieXxPuJsA9M9vn7/mUZmfUzSUTeHAeq+fEqvLltFOxcj4DVVDTYlQhgWYd+PISIWgamKw==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.0.1.tgz",
+            "integrity": "sha512-dRfAOA5Ivo+sdzzJGXEu33yAtvGg8dlZkvt/NEJ7nwi1F2j4LEdsxtfX2GKeETB2fP6XoGNSQnFXqa2NYGrHFg==",
             "dependencies": {
-                "@docusaurus/core": "3.0.0",
-                "@docusaurus/logger": "3.0.0",
-                "@docusaurus/mdx-loader": "3.0.0",
-                "@docusaurus/module-type-aliases": "3.0.0",
-                "@docusaurus/types": "3.0.0",
-                "@docusaurus/utils": "3.0.0",
-                "@docusaurus/utils-validation": "3.0.0",
+                "@docusaurus/core": "3.0.1",
+                "@docusaurus/logger": "3.0.1",
+                "@docusaurus/mdx-loader": "3.0.1",
+                "@docusaurus/module-type-aliases": "3.0.1",
+                "@docusaurus/types": "3.0.1",
+                "@docusaurus/utils": "3.0.1",
+                "@docusaurus/utils-validation": "3.0.1",
                 "@types/react-router-config": "^5.0.7",
                 "combine-promises": "^1.1.0",
                 "fs-extra": "^11.1.1",
@@ -2437,15 +2436,15 @@
             }
         },
         "node_modules/@docusaurus/plugin-content-pages": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.0.0.tgz",
-            "integrity": "sha512-EXYHXK2Ea1B5BUmM0DgSwaOYt8EMSzWtYUToNo62Q/EoWxYOQFdWglYnw3n7ZEGyw5Kog4LHaRwlazAdmDomvQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.0.1.tgz",
+            "integrity": "sha512-oP7PoYizKAXyEttcvVzfX3OoBIXEmXTMzCdfmC4oSwjG4SPcJsRge3mmI6O8jcZBgUPjIzXD21bVGWEE1iu8gg==",
             "dependencies": {
-                "@docusaurus/core": "3.0.0",
-                "@docusaurus/mdx-loader": "3.0.0",
-                "@docusaurus/types": "3.0.0",
-                "@docusaurus/utils": "3.0.0",
-                "@docusaurus/utils-validation": "3.0.0",
+                "@docusaurus/core": "3.0.1",
+                "@docusaurus/mdx-loader": "3.0.1",
+                "@docusaurus/types": "3.0.1",
+                "@docusaurus/utils": "3.0.1",
+                "@docusaurus/utils-validation": "3.0.1",
                 "fs-extra": "^11.1.1",
                 "tslib": "^2.6.0",
                 "webpack": "^5.88.1"
@@ -2459,15 +2458,15 @@
             }
         },
         "node_modules/@docusaurus/plugin-debug": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.0.0.tgz",
-            "integrity": "sha512-gSV07HfQgnUboVEb3lucuVyv5pEoy33E7QXzzn++3kSc/NLEimkjXh3sSnTGOishkxCqlFV9BHfY/VMm5Lko5g==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.0.1.tgz",
+            "integrity": "sha512-09dxZMdATky4qdsZGzhzlUvvC+ilQ2hKbYF+wez+cM2mGo4qHbv8+qKXqxq0CQZyimwlAOWQLoSozIXU0g0i7g==",
             "dependencies": {
-                "@docusaurus/core": "3.0.0",
-                "@docusaurus/types": "3.0.0",
-                "@docusaurus/utils": "3.0.0",
-                "@microlink/react-json-view": "^1.22.2",
+                "@docusaurus/core": "3.0.1",
+                "@docusaurus/types": "3.0.1",
+                "@docusaurus/utils": "3.0.1",
                 "fs-extra": "^11.1.1",
+                "react-json-view-lite": "^1.2.0",
                 "tslib": "^2.6.0"
             },
             "engines": {
@@ -2479,13 +2478,13 @@
             }
         },
         "node_modules/@docusaurus/plugin-google-analytics": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.0.0.tgz",
-            "integrity": "sha512-0zcLK8w+ohmSm1fjUQCqeRsjmQc0gflvXnaVA/QVVCtm2yCiBtkrSGQXqt4MdpD7Xq8mwo3qVd5nhIcvrcebqw==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.0.1.tgz",
+            "integrity": "sha512-jwseSz1E+g9rXQwDdr0ZdYNjn8leZBnKPjjQhMBEiwDoenL3JYFcNW0+p0sWoVF/f2z5t7HkKA+cYObrUh18gg==",
             "dependencies": {
-                "@docusaurus/core": "3.0.0",
-                "@docusaurus/types": "3.0.0",
-                "@docusaurus/utils-validation": "3.0.0",
+                "@docusaurus/core": "3.0.1",
+                "@docusaurus/types": "3.0.1",
+                "@docusaurus/utils-validation": "3.0.1",
                 "tslib": "^2.6.0"
             },
             "engines": {
@@ -2497,13 +2496,13 @@
             }
         },
         "node_modules/@docusaurus/plugin-google-gtag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.0.0.tgz",
-            "integrity": "sha512-asEKavw8fczUqvXu/s9kG2m1epLnHJ19W6CCCRZEmpnkZUZKiM8rlkDiEmxApwIc2JDDbIMk+Y2TMkJI8mInbQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.0.1.tgz",
+            "integrity": "sha512-UFTDvXniAWrajsulKUJ1DB6qplui1BlKLQZjX4F7qS/qfJ+qkKqSkhJ/F4VuGQ2JYeZstYb+KaUzUzvaPK1aRQ==",
             "dependencies": {
-                "@docusaurus/core": "3.0.0",
-                "@docusaurus/types": "3.0.0",
-                "@docusaurus/utils-validation": "3.0.0",
+                "@docusaurus/core": "3.0.1",
+                "@docusaurus/types": "3.0.1",
+                "@docusaurus/utils-validation": "3.0.1",
                 "@types/gtag.js": "^0.0.12",
                 "tslib": "^2.6.0"
             },
@@ -2516,13 +2515,13 @@
             }
         },
         "node_modules/@docusaurus/plugin-google-tag-manager": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.0.0.tgz",
-            "integrity": "sha512-lytgu2eyn+7p4WklJkpMGRhwC29ezj4IjPPmVJ8vGzcSl6JkR1sADTHLG5xWOMuci420xZl9dGEiLTQ8FjCRyA==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.0.1.tgz",
+            "integrity": "sha512-IPFvuz83aFuheZcWpTlAdiiX1RqWIHM+OH8wS66JgwAKOiQMR3+nLywGjkLV4bp52x7nCnwhNk1rE85Cpy/CIw==",
             "dependencies": {
-                "@docusaurus/core": "3.0.0",
-                "@docusaurus/types": "3.0.0",
-                "@docusaurus/utils-validation": "3.0.0",
+                "@docusaurus/core": "3.0.1",
+                "@docusaurus/types": "3.0.1",
+                "@docusaurus/utils-validation": "3.0.1",
                 "tslib": "^2.6.0"
             },
             "engines": {
@@ -2534,16 +2533,16 @@
             }
         },
         "node_modules/@docusaurus/plugin-sitemap": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.0.0.tgz",
-            "integrity": "sha512-cfcONdWku56Oi7Hdus2uvUw/RKRRlIGMViiHLjvQ21CEsEqnQ297MRoIgjU28kL7/CXD/+OiANSq3T1ezAiMhA==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.0.1.tgz",
+            "integrity": "sha512-xARiWnjtVvoEniZudlCq5T9ifnhCu/GAZ5nA7XgyLfPcNpHQa241HZdsTlLtVcecEVVdllevBKOp7qknBBaMGw==",
             "dependencies": {
-                "@docusaurus/core": "3.0.0",
-                "@docusaurus/logger": "3.0.0",
-                "@docusaurus/types": "3.0.0",
-                "@docusaurus/utils": "3.0.0",
-                "@docusaurus/utils-common": "3.0.0",
-                "@docusaurus/utils-validation": "3.0.0",
+                "@docusaurus/core": "3.0.1",
+                "@docusaurus/logger": "3.0.1",
+                "@docusaurus/types": "3.0.1",
+                "@docusaurus/utils": "3.0.1",
+                "@docusaurus/utils-common": "3.0.1",
+                "@docusaurus/utils-validation": "3.0.1",
                 "fs-extra": "^11.1.1",
                 "sitemap": "^7.1.1",
                 "tslib": "^2.6.0"
@@ -2557,23 +2556,23 @@
             }
         },
         "node_modules/@docusaurus/preset-classic": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.0.0.tgz",
-            "integrity": "sha512-90aOKZGZdi0+GVQV+wt8xx4M4GiDrBRke8NO8nWwytMEXNrxrBxsQYFRD1YlISLJSCiHikKf3Z/MovMnQpnZyg==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.0.1.tgz",
+            "integrity": "sha512-il9m9xZKKjoXn6h0cRcdnt6wce0Pv1y5t4xk2Wx7zBGhKG1idu4IFHtikHlD0QPuZ9fizpXspXcTzjL5FXc1Gw==",
             "dependencies": {
-                "@docusaurus/core": "3.0.0",
-                "@docusaurus/plugin-content-blog": "3.0.0",
-                "@docusaurus/plugin-content-docs": "3.0.0",
-                "@docusaurus/plugin-content-pages": "3.0.0",
-                "@docusaurus/plugin-debug": "3.0.0",
-                "@docusaurus/plugin-google-analytics": "3.0.0",
-                "@docusaurus/plugin-google-gtag": "3.0.0",
-                "@docusaurus/plugin-google-tag-manager": "3.0.0",
-                "@docusaurus/plugin-sitemap": "3.0.0",
-                "@docusaurus/theme-classic": "3.0.0",
-                "@docusaurus/theme-common": "3.0.0",
-                "@docusaurus/theme-search-algolia": "3.0.0",
-                "@docusaurus/types": "3.0.0"
+                "@docusaurus/core": "3.0.1",
+                "@docusaurus/plugin-content-blog": "3.0.1",
+                "@docusaurus/plugin-content-docs": "3.0.1",
+                "@docusaurus/plugin-content-pages": "3.0.1",
+                "@docusaurus/plugin-debug": "3.0.1",
+                "@docusaurus/plugin-google-analytics": "3.0.1",
+                "@docusaurus/plugin-google-gtag": "3.0.1",
+                "@docusaurus/plugin-google-tag-manager": "3.0.1",
+                "@docusaurus/plugin-sitemap": "3.0.1",
+                "@docusaurus/theme-classic": "3.0.1",
+                "@docusaurus/theme-common": "3.0.1",
+                "@docusaurus/theme-search-algolia": "3.0.1",
+                "@docusaurus/types": "3.0.1"
             },
             "engines": {
                 "node": ">=18.0"
@@ -2596,30 +2595,30 @@
             }
         },
         "node_modules/@docusaurus/theme-classic": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.0.0.tgz",
-            "integrity": "sha512-wWOHSrKMn7L4jTtXBsb5iEJ3xvTddBye5PjYBnWiCkTAlhle2yMdc4/qRXW35Ot+OV/VXu6YFG8XVUJEl99z0A==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.0.1.tgz",
+            "integrity": "sha512-XD1FRXaJiDlmYaiHHdm27PNhhPboUah9rqIH0lMpBt5kYtsGjJzhqa27KuZvHLzOP2OEpqd2+GZ5b6YPq7Q05Q==",
             "dependencies": {
-                "@docusaurus/core": "3.0.0",
-                "@docusaurus/mdx-loader": "3.0.0",
-                "@docusaurus/module-type-aliases": "3.0.0",
-                "@docusaurus/plugin-content-blog": "3.0.0",
-                "@docusaurus/plugin-content-docs": "3.0.0",
-                "@docusaurus/plugin-content-pages": "3.0.0",
-                "@docusaurus/theme-common": "3.0.0",
-                "@docusaurus/theme-translations": "3.0.0",
-                "@docusaurus/types": "3.0.0",
-                "@docusaurus/utils": "3.0.0",
-                "@docusaurus/utils-common": "3.0.0",
-                "@docusaurus/utils-validation": "3.0.0",
+                "@docusaurus/core": "3.0.1",
+                "@docusaurus/mdx-loader": "3.0.1",
+                "@docusaurus/module-type-aliases": "3.0.1",
+                "@docusaurus/plugin-content-blog": "3.0.1",
+                "@docusaurus/plugin-content-docs": "3.0.1",
+                "@docusaurus/plugin-content-pages": "3.0.1",
+                "@docusaurus/theme-common": "3.0.1",
+                "@docusaurus/theme-translations": "3.0.1",
+                "@docusaurus/types": "3.0.1",
+                "@docusaurus/utils": "3.0.1",
+                "@docusaurus/utils-common": "3.0.1",
+                "@docusaurus/utils-validation": "3.0.1",
                 "@mdx-js/react": "^3.0.0",
-                "clsx": "^1.2.1",
+                "clsx": "^2.0.0",
                 "copy-text-to-clipboard": "^3.2.0",
                 "infima": "0.2.0-alpha.43",
                 "lodash": "^4.17.21",
                 "nprogress": "^0.2.0",
                 "postcss": "^8.4.26",
-                "prism-react-renderer": "^2.1.0",
+                "prism-react-renderer": "^2.3.0",
                 "prismjs": "^1.29.0",
                 "react-router-dom": "^5.3.4",
                 "rtlcss": "^4.1.0",
@@ -2634,32 +2633,24 @@
                 "react-dom": "^18.0.0"
             }
         },
-        "node_modules/@docusaurus/theme-classic/node_modules/clsx": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-            "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/@docusaurus/theme-common": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.0.0.tgz",
-            "integrity": "sha512-PahRpCLRK5owCMEqcNtUeTMOkTUCzrJlKA+HLu7f+8osYOni617YurXvHASCsSTxurjXaLz/RqZMnASnqATxIA==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.0.1.tgz",
+            "integrity": "sha512-cr9TOWXuIOL0PUfuXv6L5lPlTgaphKP+22NdVBOYah5jSq5XAAulJTjfe+IfLsEG4L7lJttLbhW7LXDFSAI7Ag==",
             "dependencies": {
-                "@docusaurus/mdx-loader": "3.0.0",
-                "@docusaurus/module-type-aliases": "3.0.0",
-                "@docusaurus/plugin-content-blog": "3.0.0",
-                "@docusaurus/plugin-content-docs": "3.0.0",
-                "@docusaurus/plugin-content-pages": "3.0.0",
-                "@docusaurus/utils": "3.0.0",
-                "@docusaurus/utils-common": "3.0.0",
+                "@docusaurus/mdx-loader": "3.0.1",
+                "@docusaurus/module-type-aliases": "3.0.1",
+                "@docusaurus/plugin-content-blog": "3.0.1",
+                "@docusaurus/plugin-content-docs": "3.0.1",
+                "@docusaurus/plugin-content-pages": "3.0.1",
+                "@docusaurus/utils": "3.0.1",
+                "@docusaurus/utils-common": "3.0.1",
                 "@types/history": "^4.7.11",
                 "@types/react": "*",
                 "@types/react-router-config": "*",
-                "clsx": "^1.2.1",
+                "clsx": "^2.0.0",
                 "parse-numeric-range": "^1.3.0",
-                "prism-react-renderer": "^2.1.0",
+                "prism-react-renderer": "^2.3.0",
                 "tslib": "^2.6.0",
                 "utility-types": "^3.10.0"
             },
@@ -2671,24 +2662,16 @@
                 "react-dom": "^18.0.0"
             }
         },
-        "node_modules/@docusaurus/theme-common/node_modules/clsx": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-            "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/@docusaurus/theme-mermaid": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.0.0.tgz",
-            "integrity": "sha512-e5uoGmow5kk5AeiyYFHYGsM5LFg4ClCIIQQcBrD9zs1E8yxTDNX524MylO6klqqCn3TmxJ34RogEg78QnthRng==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.0.1.tgz",
+            "integrity": "sha512-jquSDnZfazABnC5i+02GzRIvufXKruKgvbYkQjKbI7/LWo0XvBs0uKAcCDGgHhth0t/ON5+Sn27joRfpeSk3Lw==",
             "dependencies": {
-                "@docusaurus/core": "3.0.0",
-                "@docusaurus/module-type-aliases": "3.0.0",
-                "@docusaurus/theme-common": "3.0.0",
-                "@docusaurus/types": "3.0.0",
-                "@docusaurus/utils-validation": "3.0.0",
+                "@docusaurus/core": "3.0.1",
+                "@docusaurus/module-type-aliases": "3.0.1",
+                "@docusaurus/theme-common": "3.0.1",
+                "@docusaurus/types": "3.0.1",
+                "@docusaurus/utils-validation": "3.0.1",
                 "mermaid": "^10.4.0",
                 "tslib": "^2.6.0"
             },
@@ -2701,21 +2684,21 @@
             }
         },
         "node_modules/@docusaurus/theme-search-algolia": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.0.0.tgz",
-            "integrity": "sha512-PyMUNIS9yu0dx7XffB13ti4TG47pJq3G2KE/INvOFb6M0kWh+wwCnucPg4WAOysHOPh+SD9fjlXILoLQstgEIA==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.0.1.tgz",
+            "integrity": "sha512-DDiPc0/xmKSEdwFkXNf1/vH1SzJPzuJBar8kMcBbDAZk/SAmo/4lf6GU2drou4Ae60lN2waix+jYWTWcJRahSA==",
             "dependencies": {
                 "@docsearch/react": "^3.5.2",
-                "@docusaurus/core": "3.0.0",
-                "@docusaurus/logger": "3.0.0",
-                "@docusaurus/plugin-content-docs": "3.0.0",
-                "@docusaurus/theme-common": "3.0.0",
-                "@docusaurus/theme-translations": "3.0.0",
-                "@docusaurus/utils": "3.0.0",
-                "@docusaurus/utils-validation": "3.0.0",
+                "@docusaurus/core": "3.0.1",
+                "@docusaurus/logger": "3.0.1",
+                "@docusaurus/plugin-content-docs": "3.0.1",
+                "@docusaurus/theme-common": "3.0.1",
+                "@docusaurus/theme-translations": "3.0.1",
+                "@docusaurus/utils": "3.0.1",
+                "@docusaurus/utils-validation": "3.0.1",
                 "algoliasearch": "^4.18.0",
                 "algoliasearch-helper": "^3.13.3",
-                "clsx": "^1.2.1",
+                "clsx": "^2.0.0",
                 "eta": "^2.2.0",
                 "fs-extra": "^11.1.1",
                 "lodash": "^4.17.21",
@@ -2730,18 +2713,10 @@
                 "react-dom": "^18.0.0"
             }
         },
-        "node_modules/@docusaurus/theme-search-algolia/node_modules/clsx": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-            "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/@docusaurus/theme-translations": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.0.0.tgz",
-            "integrity": "sha512-p/H3+5LdnDtbMU+csYukA6601U1ld2v9knqxGEEV96qV27HsHfP63J9Ta2RBZUrNhQAgrwFzIc9GdDO8P1Baag==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.0.1.tgz",
+            "integrity": "sha512-6UrbpzCTN6NIJnAtZ6Ne9492vmPVX+7Fsz4kmp+yor3KQwA1+MCzQP7ItDNkP38UmVLnvB/cYk/IvehCUqS3dg==",
             "dependencies": {
                 "fs-extra": "^11.1.1",
                 "tslib": "^2.6.0"
@@ -2751,9 +2726,9 @@
             }
         },
         "node_modules/@docusaurus/types": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.0.0.tgz",
-            "integrity": "sha512-Qb+l/hmCOVemReuzvvcFdk84bUmUFyD0Zi81y651ie3VwMrXqC7C0E7yZLKMOsLj/vkqsxHbtkAuYMI89YzNzg==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.0.1.tgz",
+            "integrity": "sha512-plyX2iU1tcUsF46uQ01pAd4JhexR7n0iiQ5MSnBFX6M6NSJgDYdru/i1/YNPKOnQHBoXGLHv0dNT6OAlDWNjrg==",
             "dependencies": {
                 "@types/history": "^4.7.11",
                 "@types/react": "*",
@@ -2770,11 +2745,11 @@
             }
         },
         "node_modules/@docusaurus/utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.0.0.tgz",
-            "integrity": "sha512-JwGjh5mtjG9XIAESyPxObL6CZ6LO/yU4OSTpq7Q0x+jN25zi/AMbvLjpSyZzWy+qm5uQiFiIhqFaOxvy+82Ekg==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.0.1.tgz",
+            "integrity": "sha512-TwZ33Am0q4IIbvjhUOs+zpjtD/mXNmLmEgeTGuRq01QzulLHuPhaBTTAC/DHu6kFx3wDgmgpAlaRuCHfTcXv8g==",
             "dependencies": {
-                "@docusaurus/logger": "3.0.0",
+                "@docusaurus/logger": "3.0.1",
                 "@svgr/webpack": "^6.5.1",
                 "escape-string-regexp": "^4.0.0",
                 "file-loader": "^6.2.0",
@@ -2805,9 +2780,9 @@
             }
         },
         "node_modules/@docusaurus/utils-common": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.0.0.tgz",
-            "integrity": "sha512-7iJWAtt4AHf4PFEPlEPXko9LZD/dbYnhLe0q8e3GRK1EXZyRASah2lznpMwB3lLmVjq/FR6ZAKF+E0wlmL5j0g==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.0.1.tgz",
+            "integrity": "sha512-W0AxD6w6T8g6bNro8nBRWf7PeZ/nn7geEWM335qHU2DDDjHuV4UZjgUGP1AQsdcSikPrlIqTJJbKzer1lRSlIg==",
             "dependencies": {
                 "tslib": "^2.6.0"
             },
@@ -2824,12 +2799,12 @@
             }
         },
         "node_modules/@docusaurus/utils-validation": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.0.0.tgz",
-            "integrity": "sha512-MlIGUspB/HBW5CYgHvRhmkZbeMiUWKbyVoCQYvbGN8S19SSzVgzyy97KRpcjCOYYeEdkhmRCUwFBJBlLg3IoNQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.0.1.tgz",
+            "integrity": "sha512-ujTnqSfyGQ7/4iZdB4RRuHKY/Nwm58IIb+41s5tCXOv/MBU2wGAjOHq3U+AEyJ8aKQcHbxvTKJaRchNHYUVUQg==",
             "dependencies": {
-                "@docusaurus/logger": "3.0.0",
-                "@docusaurus/utils": "3.0.0",
+                "@docusaurus/logger": "3.0.1",
+                "@docusaurus/utils": "3.0.1",
                 "joi": "^17.9.2",
                 "js-yaml": "^4.1.0",
                 "tslib": "^2.6.0"
@@ -3069,33 +3044,6 @@
             "peerDependencies": {
                 "@types/react": ">=16",
                 "react": ">=16"
-            }
-        },
-        "node_modules/@microlink/react-json-view": {
-            "version": "1.23.0",
-            "resolved": "https://registry.npmjs.org/@microlink/react-json-view/-/react-json-view-1.23.0.tgz",
-            "integrity": "sha512-HYJ1nsfO4/qn8afnAMhuk7+5a1vcjEaS8Gm5Vpr1SqdHDY0yLBJGpA+9DvKyxyVKaUkXzKXt3Mif9RcmFSdtYg==",
-            "dependencies": {
-                "flux": "~4.0.1",
-                "react-base16-styling": "~0.6.0",
-                "react-lifecycles-compat": "~3.0.4",
-                "react-textarea-autosize": "~8.3.2"
-            },
-            "peerDependencies": {
-                "react": ">= 15",
-                "react-dom": ">= 15"
-            }
-        },
-        "node_modules/@microlink/react-json-view/node_modules/flux": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.4.tgz",
-            "integrity": "sha512-NCj3XlayA2UsapRpM7va6wU1+9rE5FIL7qoMcmxWHRzbp0yujihMBm9BBHZ1MDIk5h5o2Bl6eGiCe8rYELAmYw==",
-            "dependencies": {
-                "fbemitter": "^3.0.0",
-                "fbjs": "^3.0.1"
-            },
-            "peerDependencies": {
-                "react": "^15.0.2 || ^16.0.0 || ^17.0.0"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -3618,9 +3566,9 @@
             }
         },
         "node_modules/@types/eslint": {
-            "version": "8.44.7",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.7.tgz",
-            "integrity": "sha512-f5ORu2hcBbKei97U73mf+l9t4zTGl74IqZ0GQk4oVea/VS8tQZYkUveSYojk+frraAVYId0V2WC9O4PTNru2FQ==",
+            "version": "8.44.8",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.8.tgz",
+            "integrity": "sha512-4K8GavROwhrYl2QXDXm0Rv9epkA8GBFu0EI+XrrnnuCl7u8CWBRusX7fXJfanhZTDWSAL24gDI/UqXyUM0Injw==",
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -3761,9 +3709,9 @@
             "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
         },
         "node_modules/@types/node": {
-            "version": "20.10.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.0.tgz",
-            "integrity": "sha512-D0WfRmU9TQ8I9PFx9Yc+EBHw+vSpIub4IDvQivcp26PtPrdMGAq5SDcpXEo/epqa/DXotVpekHiLNTg3iaKXBQ==",
+            "version": "20.10.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.1.tgz",
+            "integrity": "sha512-T2qwhjWwGH81vUEx4EXmBKsTJRXFXNZTL4v0gi01+zyBmCwzE6TyHszqX01m+QHTEq+EZNo13NeJIdEqf+Myrg==",
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -3802,9 +3750,9 @@
             "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
         },
         "node_modules/@types/react": {
-            "version": "18.2.38",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.38.tgz",
-            "integrity": "sha512-cBBXHzuPtQK6wNthuVMV6IjHAFkdl/FOPFIlkd81/Cd1+IqkHu/A+w4g43kaQQoYHik/ruaQBDL72HyCy1vuMw==",
+            "version": "18.2.39",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.39.tgz",
+            "integrity": "sha512-Oiw+ppED6IremMInLV4HXGbfbG6GyziY3kqAwJYOR0PNbkYDmLWQA3a95EhdSmamsvbkJN96ZNN+YD+fGjzSBA==",
             "dependencies": {
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",
@@ -4313,11 +4261,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/asap": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-            "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
-        },
         "node_modules/astring": {
             "version": "1.8.6",
             "resolved": "https://registry.npmjs.org/astring/-/astring-1.8.6.tgz",
@@ -4329,7 +4272,8 @@
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "dev": true
         },
         "node_modules/at-least-node": {
             "version": "1.0.0",
@@ -4391,6 +4335,7 @@
             "version": "1.6.2",
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
             "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+            "dev": true,
             "dependencies": {
                 "follow-redirects": "^1.15.0",
                 "form-data": "^4.0.0",
@@ -4478,11 +4423,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-        },
-        "node_modules/base16": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz",
-            "integrity": "sha512-pNdYkNPiJUnEhnfXV56+sQy8+AaPcG3POZAUnwr4EeqCUZFz4u2PePbo3e5Gj4ziYPCWGUZT9RHisvJKnwFuBQ=="
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
@@ -4789,9 +4729,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001564",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001564.tgz",
-            "integrity": "sha512-DqAOf+rhof+6GVx1y+xzbFPeOumfQnhYzVnZD6LAXijR77yPtm9mfOcqOnT3mpnJiZVT+kwLAFnRlZcIz+c6bg==",
+            "version": "1.0.30001565",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001565.tgz",
+            "integrity": "sha512-xrE//a3O7TP0vaJ8ikzkD2c2NgcVUvsEe2IvFTntV4Yd1Z9FVzh+gW+enX96L0psrbaFMcVcH2l90xNuGDWc8w==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -4974,9 +4914,9 @@
             }
         },
         "node_modules/clean-css": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.2.tgz",
-            "integrity": "sha512-JVJbM+f3d3Q704rF4bqQ5UUyTtuJ0JRKNbTKVEeujCCBoMdkEi+V+e8oktO9qGQNSvHrFTM6JZRXrUvGR1czww==",
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+            "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
             "dependencies": {
                 "source-map": "~0.6.0"
             },
@@ -5131,6 +5071,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -5417,14 +5358,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/cross-fetch": {
-            "version": "3.1.8",
-            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
-            "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
-            "dependencies": {
-                "node-fetch": "^2.6.12"
             }
         },
         "node_modules/cross-spawn": {
@@ -6398,6 +6331,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "dev": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -6638,9 +6572,9 @@
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.594",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.594.tgz",
-            "integrity": "sha512-xT1HVAu5xFn7bDfkjGQi9dNpMqGchUkebwf1GL7cZN32NSwwlHRPMSDJ1KN6HkS0bWUtndbSQZqvpQftKG2uFQ=="
+            "version": "1.4.600",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.600.tgz",
+            "integrity": "sha512-KD6CWjf1BnQG+NsXuyiTDDT1eV13sKuYsOUioXkQweYTQIbgHkXPry9K7M+7cKtYHnSUPitVaLrXYB1jTkkYrw=="
         },
         "node_modules/elkjs": {
             "version": "0.8.2",
@@ -7153,33 +7087,6 @@
                 "node": ">=0.8.0"
             }
         },
-        "node_modules/fbemitter": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-3.0.0.tgz",
-            "integrity": "sha512-KWKaceCwKQU0+HPoop6gn4eOHk50bBv/VxjJtGMfwmJt3D29JpN4H4eisCtIPA+a8GVBam+ldMMpMjJUvpDyHw==",
-            "dependencies": {
-                "fbjs": "^3.0.0"
-            }
-        },
-        "node_modules/fbjs": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.5.tgz",
-            "integrity": "sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==",
-            "dependencies": {
-                "cross-fetch": "^3.1.5",
-                "fbjs-css-vars": "^1.0.0",
-                "loose-envify": "^1.0.0",
-                "object-assign": "^4.1.0",
-                "promise": "^7.1.1",
-                "setimmediate": "^1.0.5",
-                "ua-parser-js": "^1.0.35"
-            }
-        },
-        "node_modules/fbjs-css-vars": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
-            "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
-        },
         "node_modules/feed": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/feed/-/feed-4.2.2.tgz",
@@ -7511,6 +7418,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
             "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "dev": true,
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
@@ -7565,9 +7473,9 @@
             }
         },
         "node_modules/fs-extra": {
-            "version": "11.1.1",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-            "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
             "dependencies": {
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^6.0.1",
@@ -8053,23 +7961,42 @@
             }
         },
         "node_modules/hast-util-to-jsx-runtime": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.2.0.tgz",
-            "integrity": "sha512-wSlp23N45CMjDg/BPW8zvhEi3R+8eRE1qFbjEyAUzMCzu2l1Wzwakq+Tlia9nkCtEl5mDxa7nKHsvYJ6Gfn21A==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.0.tgz",
+            "integrity": "sha512-H/y0+IWPdsLLS738P8tDnrQ8Z+dj12zQQ6WC11TIM21C8WFVoIxcqWXf2H3hiTVZjF1AWqoimGwrTWecWrnmRQ==",
             "dependencies": {
+                "@types/estree": "^1.0.0",
                 "@types/hast": "^3.0.0",
                 "@types/unist": "^3.0.0",
                 "comma-separated-tokens": "^2.0.0",
+                "devlop": "^1.0.0",
+                "estree-util-is-identifier-name": "^3.0.0",
                 "hast-util-whitespace": "^3.0.0",
+                "mdast-util-mdx-expression": "^2.0.0",
+                "mdast-util-mdx-jsx": "^3.0.0",
+                "mdast-util-mdxjs-esm": "^2.0.0",
                 "property-information": "^6.0.0",
                 "space-separated-tokens": "^2.0.0",
-                "style-to-object": "^0.4.0",
+                "style-to-object": "^1.0.0",
                 "unist-util-position": "^5.0.0",
                 "vfile-message": "^4.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-to-jsx-runtime/node_modules/inline-style-parser": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.2.tgz",
+            "integrity": "sha512-EcKzdTHVe8wFVOGEYXiW9WmJXPjqi1T+234YpJr98RiFYKHV3cdy1+3mkTE+KHTHxFFLH51SfaGOoUdW+v7ViQ=="
+        },
+        "node_modules/hast-util-to-jsx-runtime/node_modules/style-to-object": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.5.tgz",
+            "integrity": "sha512-rDRwHtoDD3UMMrmZ6BzOW0naTjMsVZLIjsGleSKS/0Oz+cgCfAPRspaqJuE8rDzpKha/nEvnM0IF4seEAZUTKQ==",
+            "dependencies": {
+                "inline-style-parser": "0.2.2"
             }
         },
         "node_modules/hast-util-to-parse5": {
@@ -9372,20 +9299,10 @@
             "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
             "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
         },
-        "node_modules/lodash.curry": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
-            "integrity": "sha512-/u14pXGviLaweY5JI0IUzgzF2J6Ne8INyzAZjImcryjgkZ+ebruBxy2/JaOOkTqScddcYtakjhSaeemV8lR0tA=="
-        },
         "node_modules/lodash.debounce": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
-        },
-        "node_modules/lodash.flow": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
-            "integrity": "sha512-ff3BX/tSioo+XojX4MOsOMhJw0nZoUEF011LX8g8d3gvjVbxd89cCio4BCXronjxcTUIJUoqKEUA+n4CqvvRPw=="
         },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
@@ -12211,25 +12128,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/node-forge": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -12239,9 +12137,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.13",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-            "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+            "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
         },
         "node_modules/non-layered-tidy-tree-layout": {
             "version": "2.0.2",
@@ -12343,12 +12241,12 @@
             }
         },
         "node_modules/object.assign": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-            "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+            "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.4",
+                "call-bind": "^1.0.5",
+                "define-properties": "^1.2.1",
                 "has-symbols": "^1.0.3",
                 "object-keys": "^1.1.1"
             },
@@ -12733,9 +12631,9 @@
             }
         },
         "node_modules/photoswipe": {
-            "version": "5.4.2",
-            "resolved": "https://registry.npmjs.org/photoswipe/-/photoswipe-5.4.2.tgz",
-            "integrity": "sha512-z5hr36nAIPOZbHJPbCJ/mQ3+ZlizttF9za5gKXKH/us1k4KNHaRbC63K1Px5sVVKUtGb/2+ixHpKqtwl0WAwvA==",
+            "version": "5.4.3",
+            "resolved": "https://registry.npmjs.org/photoswipe/-/photoswipe-5.4.3.tgz",
+            "integrity": "sha512-9UC6oJBK4oXFZ5HcdlcvGkfEHsVrmE4csUdCQhEjHYb3PvPLO3PG7UhnPuOgjxwmhq5s17Un5NUdum01LgBDng==",
             "engines": {
                 "node": ">= 0.12.0"
             }
@@ -13499,14 +13397,6 @@
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
-        "node_modules/promise": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-            "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-            "dependencies": {
-                "asap": "~2.0.3"
-            }
-        },
         "node_modules/prompts": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -13566,7 +13456,8 @@
         "node_modules/proxy-from-env": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "dev": true
         },
         "node_modules/punycode": {
             "version": "1.4.1",
@@ -13586,11 +13477,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/pure-color": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/pure-color/-/pure-color-1.3.0.tgz",
-            "integrity": "sha512-QFADYnsVoBMw1srW7OVKEYjG+MbIa49s54w1MA1EDY6r2r/sTcKKYqRX1f4GYvnXP7eN/Pe9HFcX+hwzmrXRHA=="
         },
         "node_modules/qs": {
             "version": "6.11.0",
@@ -13724,17 +13610,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/react-base16-styling": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/react-base16-styling/-/react-base16-styling-0.6.0.tgz",
-            "integrity": "sha512-yvh/7CArceR/jNATXOKDlvTnPKPmGZz7zsenQ3jUwLzHkNUR0CvY3yGYJbWJ/nnxsL8Sgmt5cO3/SILVuPO6TQ==",
-            "dependencies": {
-                "base16": "^1.0.0",
-                "lodash.curry": "^4.0.1",
-                "lodash.flow": "^3.3.0",
-                "pure-color": "^1.2.0"
             }
         },
         "node_modules/react-dev-utils": {
@@ -13898,10 +13773,16 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
-        "node_modules/react-lifecycles-compat": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-            "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+        "node_modules/react-json-view-lite": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-1.2.1.tgz",
+            "integrity": "sha512-Itc0g86fytOmKZoIoJyGgvNqohWSbh3NXIKNgH6W6FT9PC1ck4xas1tT3Rr/b3UlFXyA9Jjaw9QSXdZy2JwGMQ==",
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
+            }
         },
         "node_modules/react-loadable": {
             "name": "@docusaurus/react-loadable",
@@ -13977,22 +13858,6 @@
             },
             "peerDependencies": {
                 "react": ">=15"
-            }
-        },
-        "node_modules/react-textarea-autosize": {
-            "version": "8.3.4",
-            "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
-            "integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
-            "dependencies": {
-                "@babel/runtime": "^7.10.2",
-                "use-composed-ref": "^1.3.0",
-                "use-latest": "^1.2.1"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
             }
         },
         "node_modules/readable-stream": {
@@ -14553,14 +14418,6 @@
             "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
             "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
         },
-        "node_modules/rxjs": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-            "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-            "dependencies": {
-                "tslib": "^2.1.0"
-            }
-        },
         "node_modules/sade": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
@@ -14914,11 +14771,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/setimmediate": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
-        },
         "node_modules/setprototypeof": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -15194,9 +15046,9 @@
             }
         },
         "node_modules/std-env": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.5.0.tgz",
-            "integrity": "sha512-JGUEaALvL0Mf6JCfYnJOTcobY+Nc7sG/TemDRBqCA0wEr4DER7zDchaaixTlmOxAjG1uRJmX82EQcxwTQTkqVA=="
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.6.0.tgz",
+            "integrity": "sha512-aFZ19IgVmhdB2uX599ve2kE6BIE3YMnQ6Gp6BURhW/oIzpXGKr878TQfAQZn1+i0Flcc/UKUy1gOlcfaUBCryg=="
         },
         "node_modules/stop-iteration-iterator": {
             "version": "1.0.0",
@@ -15674,11 +15526,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-        },
         "node_modules/transformation-matrix": {
             "version": "2.15.0",
             "resolved": "https://registry.npmjs.org/transformation-matrix/-/transformation-matrix-2.15.0.tgz",
@@ -15761,28 +15608,6 @@
             },
             "engines": {
                 "node": ">=14.17"
-            }
-        },
-        "node_modules/ua-parser-js": {
-            "version": "1.0.37",
-            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.37.tgz",
-            "integrity": "sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ==",
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/ua-parser-js"
-                },
-                {
-                    "type": "paypal",
-                    "url": "https://paypal.me/faisalman"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/faisalman"
-                }
-            ],
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/undici-types": {
@@ -16176,43 +16001,6 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
-        "node_modules/use-composed-ref": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
-            "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-            }
-        },
-        "node_modules/use-isomorphic-layout-effect": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
-            "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/use-latest": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
-            "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
-            "dependencies": {
-                "use-isomorphic-layout-effect": "^1.1.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -16329,24 +16117,6 @@
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/wait-on": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
-            "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
-            "dependencies": {
-                "axios": "^1.6.1",
-                "joi": "^17.11.0",
-                "lodash": "^4.17.21",
-                "minimist": "^1.2.8",
-                "rxjs": "^7.8.1"
-            },
-            "bin": {
-                "wait-on": "bin/wait-on"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
         "node_modules/watchpack": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -16380,11 +16150,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
             "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="
-        },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
         },
         "node_modules/webpack": {
             "version": "5.89.0",
@@ -16676,15 +16441,6 @@
             "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
             "engines": {
                 "node": ">=0.8.0"
-            }
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
         "clsx": "^2.0.0",
         "mermaid": "^10.6.1",
         "photoswipe": "^5.4.3",
-        "plugin-image-zoom": "github:flexanalytics/plugin-image-zoom",
         "prism-react-renderer": "^2.3.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -17,20 +17,20 @@
         "render-diagrams": "node scripts/renderDiagrams.js"
     },
     "dependencies": {
-        "@docusaurus/core": "3.0.0",
-        "@docusaurus/preset-classic": "3.0.0",
-        "@docusaurus/theme-mermaid": "^3.0.0",
+        "@docusaurus/core": "^3.0.1",
+        "@docusaurus/preset-classic": "^3.0.1",
+        "@docusaurus/theme-mermaid": "^3.0.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "mermaid": "^10.6.1",
-        "photoswipe": "^5.4.2",
+        "photoswipe": "^5.4.3",
         "plugin-image-zoom": "github:flexanalytics/plugin-image-zoom",
-        "prism-react-renderer": "^2.1.0",
+        "prism-react-renderer": "^2.3.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
     },
     "devDependencies": {
-        "@docusaurus/module-type-aliases": "3.0.0",
+        "@docusaurus/module-type-aliases": "^3.0.1",
         "@hylimo/cli": "^0.0.1",
         "prettier": "^3.1.0"
     },

--- a/src/components/HylimoDiagram.js
+++ b/src/components/HylimoDiagram.js
@@ -1,6 +1,7 @@
 import { useColorMode } from "@docusaurus/theme-common";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import Lightbox from "./Lightbox";
+import BrowserOnly from "@docusaurus/BrowserOnly";
 
 export default function HylimoDiagram({ name, alt, width, height }) {
     const { colorMode } = useColorMode();
@@ -11,5 +12,5 @@ export default function HylimoDiagram({ name, alt, width, height }) {
         height
     };
 
-    return <Lightbox image={image} />;
+    return <BrowserOnly>{() => <Lightbox image={image} />}</BrowserOnly>;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -34,3 +34,7 @@
 .pswp__img {
   background: var(--background-color);
 }
+
+.pswp.pswp--open {
+  display: block;
+}


### PR DESCRIPTION
- upgrades dependencies
- fixes lightbox css
  - lightbox uses two class selectors with the same specificity, thus, the priority is based on the order
  - however, webpack merges some selectors and changes the priority in a production build
  - as a fix, added the important selector with more specificity
- also adds a workaround for https://github.com/facebook/docusaurus/issues/7986