### PR TITLE
Fix order of Docs categories, update overview

### DIFF
--- a/docs/docs/dev-manuals/_category_.json
+++ b/docs/docs/dev-manuals/_category_.json
@@ -1,6 +1,6 @@
 {
     "label": "Development",
-    "position": 3,
+    "position": 4,
     "link": {
         "type": "generated-index",
         "description": "What to keep in mind when developing it"

--- a/docs/docs/install-manuals/_category_.json
+++ b/docs/docs/install-manuals/_category_.json
@@ -1,6 +1,6 @@
 {
     "label": "Installation",
-    "position": 1,
+    "position": 2,
     "link": {
         "type": "generated-index",
         "description": "How to install it"

--- a/docs/docs/overview.mdx
+++ b/docs/docs/overview.mdx
@@ -39,6 +39,7 @@ The aim of this development project is to create such a reference architecture.
 See
 
 - [Installation](/docs/category/installation) for details regarding system requirements and setup
+- [Usage](/docs/category/usage) for user manuals, e.g. the [Frontend User Guide](/docs/docs/user-manuals/how-to-use-frontend)
 - [Architecture](/docs/category/architecture) for the architectural process
 - [Services](/docs/category/services) for detailed documentation of every service
 - [Architectural Decision Records](/docs/category/adrs) for the architectural decisions

--- a/docs/docs/user-manuals/_category_.json
+++ b/docs/docs/user-manuals/_category_.json
@@ -1,6 +1,6 @@
 {
     "label": "Usage",
-    "position": 2,
+    "position": 3,
     "link": {
         "type": "generated-index",
         "description": "How to use it"


### PR DESCRIPTION
### Requirements / Objective
With the addition of the Frontend User Guide, the Docs section "Usage" became visible for the first time. The "Usage" section had yet to be mentioned in the "Project Overview" page.

### What I did
- Fix the order of the four main level Docs items: Project Overview should come first before Installation, Usage, and Development
- Add link to Usage page to Overview section Documentation

This is a follow up feature due to [Gropius Issue regarding Frontend User Guide](https://frontend.gropius.duckdns.org/components/9d12d6ac-e85a-407c-bdff-a8321fb75d3a/issues/f8a6d998-34f2-4ddf-895e-1fc04f99f7b8) getting merged after the [introduction of the Project Overview Page](https://frontend.gropius.duckdns.org/components/3bf3927b-f8b1-4317-a802-24850c5ac9ca/issues/a1246326-30d8-43d7-b12d-53acbc6f0f7d).

### Definition of Done
- [x] Requirements of the issue are met
- [x] Code has been reviewed