### PR TITLE
Update README: Add section RE schemas submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,22 @@ This documentation for MiSArch is built using [Docusaurus 2](https://docusaurus.
 npm i
 ```
 
+### Submodules
+
+In both sections of this _README_, [Local Development](#local-development) and [Build](#build), the following command will be issued:
+
+```
+npm run update-graphql-docs
+```
+
+`update-graphql-docs` creates the GraphQL API documentation and for it to work it expects the submodule [schemas](https://github.com/MiSArch/schemas.git) to be initialized and up-to-date. Because of that we have to execute the following command at first (ideally right after `npm i`):
+
+```
+git submodule update --init
+```
+
+Note that `npm run render-diagrams` does not depend on the submodule.
+
 ### Local Development
 
 ```


### PR DESCRIPTION
### Summary

IMO, the _README_ of this repo is missing a section regarding the schemas submodule. If one does not execute `git submodule update --init` before `npm run update-graphql-docs` then the second command does not work as expected. Therefore the git submodule step should be added to the documentation.

### Expected Behavior

As a developer that has to update docs for the first time, I expect the _README_ to set me up without any issues.

### Actual Behavior

`npm run update-graphql-docs` ends up in an error if I did not execute `git submodule update --init` beforehand.

### Definition of Done
- [x] Requirements of the issue are met
- [x] Code has been reviewed